### PR TITLE
added passing alignRight prop from column settings

### DIFF
--- a/src/DataTables/DataTables.js
+++ b/src/DataTables/DataTables.js
@@ -416,6 +416,7 @@ class DataTables extends Component {
                     sortable={sortable}
                     sorted={sorted}
                     order={order}
+                    alignRight={column.alignRight}
                     className={column.className}
                   >
                     <span>{column.label}</span>


### PR DESCRIPTION
Hi, you are using alignRight prop in DataTablesHeaderColumn component, but it's not passed from DataTable. This prop is used for placing sorting arrow before column label.